### PR TITLE
Feature/add client data

### DIFF
--- a/src/components/controller/controller.js
+++ b/src/components/controller/controller.js
@@ -15,7 +15,6 @@ import getServiceInfo from './ops/get_service_info.js';
 import checkUsername from './ops/check_username.js';
 
 function tryAndCatch (ctx, fun) {
-  // $FlowFixMe
   return async (...args) => {
     try {
       return await fun(ctx, ...args);

--- a/src/components/controller/controller.js
+++ b/src/components/controller/controller.js
@@ -15,7 +15,7 @@ import getServiceInfo from './ops/get_service_info.js';
 import checkUsername from './ops/check_username.js';
 
 function tryAndCatch (ctx, fun) {
-  return async (...args) => {
+  return async (...args: Array<*>) => {
     try {
       return await fun(ctx, ...args);
     } catch (err) {

--- a/src/components/controller/ops/accept_access.js
+++ b/src/components/controller/ops/accept_access.js
@@ -12,10 +12,19 @@ async function acceptAccess (
 
   if (updateId != null) {
     // Update existing app access
-    appAccess = await ctx.pryv.updateAppAccess(updateId, ctx.user.username, ctx.permissions.list, ctx.user.personalToken);
+    appAccess = await ctx.pryv.updateAppAccess(
+      updateId,
+      ctx.user.username,
+      ctx.user.personalToken,
+      ctx.permissions.list,
+      ctx.clientData);
   } else {
     // Create a new app access
-    appAccess = await ctx.pryv.createAppAccess(ctx.user.username, ctx.permissions.list, ctx.user.personalToken);
+    appAccess = await ctx.pryv.createAppAccess(
+      ctx.user.username,
+      ctx.user.personalToken,
+      ctx.permissions.list,
+      ctx.clientData);
   }
 
   // Notify register about accepted state

--- a/src/components/controller/ops/accept_access.js
+++ b/src/components/controller/ops/accept_access.js
@@ -1,6 +1,7 @@
 // @flow
 
-import {AcceptedAuthState} from '../../models/AuthStates.js';
+import {ACCEPTED_STATUS} from '../../models/AuthStates.js';
+import type {AcceptedAuthState} from '../../models/AuthStates.js';
 import closeOrRedirect from './close_or_redirect.js';
 import type Context from '../../../context.js';
 
@@ -18,7 +19,11 @@ async function acceptAccess (
   }
 
   // Notify register about accepted state
-  const acceptedState = new AcceptedAuthState(ctx.user.username, appAccess.token);
+  const acceptedState: AcceptedAuthState = {
+    status: ACCEPTED_STATUS,
+    username: ctx.user.username,
+    token: appAccess.token,
+  };
   await ctx.pryv.updateAuthState(ctx.pollKey, acceptedState);
 
   closeOrRedirect(ctx, acceptedState);

--- a/src/components/controller/ops/accept_access.js
+++ b/src/components/controller/ops/accept_access.js
@@ -5,27 +5,14 @@ import type {AcceptedAuthState} from '../../models/AuthStates.js';
 import closeOrRedirect from './close_or_redirect.js';
 import type Context from '../../../context.js';
 
-async function acceptAccess (
-  ctx: Context,
-  updateId: ?string): Promise<void> {
-  let appAccess;
-
-  if (updateId != null) {
-    // Update existing app access
-    appAccess = await ctx.pryv.updateAppAccess(
-      updateId,
-      ctx.user.username,
-      ctx.user.personalToken,
-      ctx.permissions.list,
-      ctx.clientData);
-  } else {
-    // Create a new app access
-    appAccess = await ctx.pryv.createAppAccess(
-      ctx.user.username,
-      ctx.user.personalToken,
-      ctx.permissions.list,
-      ctx.clientData);
-  }
+async function acceptAccess (ctx: Context): Promise<void> {
+  // Create a new app access
+  const appAccess = await ctx.pryv.createAppAccess(
+    ctx.user.username,
+    ctx.user.personalToken,
+    ctx.permissions.list,
+    ctx.requestingAppId,
+    ctx.clientData);
 
   // Notify register about accepted state
   const acceptedState: AcceptedAuthState = {

--- a/src/components/controller/ops/change_password.js
+++ b/src/components/controller/ops/change_password.js
@@ -8,7 +8,11 @@ async function changePassword (
   newPassword: string,
   resetToken: string): Promise<void> {
   await checkUsername(ctx);
-  await ctx.pryv.changePassword(ctx.user.username, newPassword, resetToken);
+  await ctx.pryv.changePassword(
+    ctx.user.username,
+    newPassword,
+    resetToken,
+    ctx.appId);
 }
 
 export default changePassword;

--- a/src/components/controller/ops/check_access.js
+++ b/src/components/controller/ops/check_access.js
@@ -1,7 +1,8 @@
 // @flow
 
 import type Context from '../../../Context.js';
-import {AcceptedAuthState} from '../../models/AuthStates.js';
+import type {AcceptedAuthState, NeedSigninState} from '../../models/AuthStates.js';
+import {ACCEPTED_STATUS, NEED_SIGNIN_STATUS} from '../../models/AuthStates.js';
 import closeOrRedirect from './close_or_redirect.js';
 import login from './login.js';
 
@@ -9,6 +10,18 @@ async function checkAccess (
   ctx: Context,
   password: string,
   showPermissions: (?string) => void): Promise<void> {
+  // Retrieve auth request parameters
+  const authState = await ctx.pryv.poll(ctx.pollKey);
+  switch (authState.status) {
+    case NEED_SIGNIN_STATUS:
+      // Auth request is pending
+      const pendingAuthState: NeedSigninState = authState;
+      ctx.syncFromAuthState(pendingAuthState);
+      break;
+    default:
+      // Auth request was already accepted or terminated (error/refused)
+      return closeOrRedirect(ctx, authState);
+  }
   // Login against Pryv
   await login(ctx, password);
 
@@ -17,7 +30,11 @@ async function checkAccess (
 
   // A matching access exists, returning it alongside with accepted state
   if (checkApp.match) {
-    const acceptedState = new AcceptedAuthState(ctx.user.username, checkApp.match.token);
+    const acceptedState: AcceptedAuthState = {
+      status: ACCEPTED_STATUS,
+      username: ctx.user.username,
+      token: checkApp.match.token,
+    };
     await ctx.pryv.updateAuthState(ctx.pollKey, acceptedState);
     return closeOrRedirect(ctx, acceptedState);
   }

--- a/src/components/controller/ops/check_access.js
+++ b/src/components/controller/ops/check_access.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type Context from '../../../Context.js';
-import type {AcceptedAuthState, NeedSigninState} from '../../models/AuthStates.js';
+import type {AuthState, TerminationAuthState, AcceptedAuthState, NeedSigninState} from '../../models/AuthStates.js';
 import {ACCEPTED_STATUS, NEED_SIGNIN_STATUS} from '../../models/AuthStates.js';
 import closeOrRedirect from './close_or_redirect.js';
 import login from './login.js';
@@ -11,7 +11,7 @@ async function checkAccess (
   password: string,
   showPermissions: (?string) => void): Promise<void> {
   // Retrieve auth request parameters
-  const authState = await ctx.pryv.poll(ctx.pollKey);
+  const authState: AuthState = await ctx.pryv.poll(ctx.pollKey);
   switch (authState.status) {
     case NEED_SIGNIN_STATUS:
       // Auth request is pending
@@ -20,7 +20,8 @@ async function checkAccess (
       break;
     default:
       // Auth request was already accepted or terminated (error/refused)
-      return closeOrRedirect(ctx, authState);
+      const terminationAuthState: TerminationAuthState = authState;
+      return closeOrRedirect(ctx, terminationAuthState);
   }
   // Login against Pryv
   await login(ctx, password);

--- a/src/components/controller/ops/check_access.js
+++ b/src/components/controller/ops/check_access.js
@@ -15,8 +15,8 @@ async function checkAccess (
   switch (authState.status) {
     case NEED_SIGNIN_STATUS:
       // Auth request is pending
-      const pendingAuthState: NeedSigninState = authState;
-      ctx.syncFromAuthState(pendingAuthState);
+      const needSigninState: NeedSigninState = authState;
+      ctx.updateFromAuthState(needSigninState);
       break;
     default:
       // Auth request was already accepted or terminated (error/refused)
@@ -26,7 +26,11 @@ async function checkAccess (
   await login(ctx, password);
 
   // Check for existing app access
-  const checkApp = await ctx.pryv.checkAppAccess(ctx.user.username, ctx.permissions.list, ctx.user.personalToken);
+  const checkApp = await ctx.pryv.checkAppAccess(
+    ctx.user.username,
+    ctx.permissions.list,
+    ctx.user.personalToken,
+    ctx.requestingAppId);
 
   // A matching access exists, returning it alongside with accepted state
   if (checkApp.match) {

--- a/src/components/controller/ops/close_or_redirect.js
+++ b/src/components/controller/ops/close_or_redirect.js
@@ -16,9 +16,11 @@ function closeOrRedirect (ctx: Context, state: TerminationAuthState): void {
     } else {
       returnUrl += `?prYvkey=${ctx.pollKey}`;
 
-      Object.keys(state).forEach(key => {
-        returnUrl += `&prYv${key}=${state[key]}`;
-      });
+      for (const [key, val] of Object.entries(state)) {
+        if (typeof val === 'string' || typeof val === 'number') {
+          returnUrl += `&prYv${key}=${val}`;
+        }
+      }
     }
     location.href = returnUrl;
   }

--- a/src/components/controller/ops/close_or_redirect.js
+++ b/src/components/controller/ops/close_or_redirect.js
@@ -16,9 +16,9 @@ function closeOrRedirect (ctx: Context, state: AuthState): void {
     } else {
       href += `?prYvkey=${ctx.pollKey}`;
 
-      Object.keys(state.body).forEach(key => {
+      Object.keys(state).forEach(key => {
         // $FlowFixMe
-        href += `&prYv${key}=${state.body[key]}`;
+        href += `&prYv${key}=${state[key]}`;
       });
     }
     location.href = href;

--- a/src/components/controller/ops/close_or_redirect.js
+++ b/src/components/controller/ops/close_or_redirect.js
@@ -1,9 +1,9 @@
 // @flow
 
 import type Context from '../../../Context.js';
-import type {AuthState} from '../../models/AuthStates.js';
+import type {TerminationAuthState} from '../../models/AuthStates.js';
 
-function closeOrRedirect (ctx: Context, state: AuthState): void {
+function closeOrRedirect (ctx: Context, state: TerminationAuthState): void {
   let returnUrl = ctx.returnURL;
   // If no return URL was provided, just close the popup
   if (returnUrl == null || returnUrl === 'false' || !returnUrl) {

--- a/src/components/controller/ops/close_or_redirect.js
+++ b/src/components/controller/ops/close_or_redirect.js
@@ -17,7 +17,6 @@ function closeOrRedirect (ctx: Context, state: AuthState): void {
       returnUrl += `?prYvkey=${ctx.pollKey}`;
 
       Object.keys(state).forEach(key => {
-        // $FlowFixMe
         returnUrl += `&prYv${key}=${state[key]}`;
       });
     }

--- a/src/components/controller/ops/close_or_redirect.js
+++ b/src/components/controller/ops/close_or_redirect.js
@@ -4,24 +4,24 @@ import type Context from '../../../Context.js';
 import type {AuthState} from '../../models/AuthStates.js';
 
 function closeOrRedirect (ctx: Context, state: AuthState): void {
-  let href = ctx.returnURL;
+  let returnUrl = ctx.returnURL;
   // If no return URL was provided, just close the popup
-  if (href == null || href === 'false') {
+  if (returnUrl == null || returnUrl === 'false' || !returnUrl) {
     window.close();
   } else {
     // Otherwise, we need to redirect to the return URL,
     // passing the resulting parameters as querystring
     if (ctx.oauthState) {
-      href += `?state=${ctx.oauthState}&code=${ctx.pollKey}`;
+      returnUrl += `?state=${ctx.oauthState}&code=${ctx.pollKey}`;
     } else {
-      href += `?prYvkey=${ctx.pollKey}`;
+      returnUrl += `?prYvkey=${ctx.pollKey}`;
 
       Object.keys(state).forEach(key => {
         // $FlowFixMe
-        href += `&prYv${key}=${state[key]}`;
+        returnUrl += `&prYv${key}=${state[key]}`;
       });
     }
-    location.href = href;
+    location.href = returnUrl;
   }
 }
 

--- a/src/components/controller/ops/create_user.js
+++ b/src/components/controller/ops/create_user.js
@@ -10,7 +10,13 @@ async function createUser (
   hosting: string,
 ): Promise<NewUser> {
   // Create the new user
-  const newUser = await ctx.pryv.createUser(ctx.user.username, password, email, hosting, ctx.language);
+  const newUser = await ctx.pryv.createUser(
+    ctx.user.username,
+    password,
+    email,
+    hosting,
+    ctx.language,
+    ctx.appId);
   return newUser;
 }
 

--- a/src/components/controller/ops/create_user.js
+++ b/src/components/controller/ops/create_user.js
@@ -10,7 +10,7 @@ async function createUser (
   hosting: string,
 ): Promise<NewUser> {
   // Create the new user
-  const newUser = await ctx.pryv.createUser(ctx.user.username, password, email, hosting);
+  const newUser = await ctx.pryv.createUser(ctx.user.username, password, email, hosting, ctx.language);
   return newUser;
 }
 

--- a/src/components/controller/ops/load_hostings.js
+++ b/src/components/controller/ops/load_hostings.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type Context from '../../../Context.js';
-import type HostingSelection from '../../models/Hostings.js';
+import type {HostingSelection} from '../../models/Hostings.js';
 
 async function loadHostings (ctx: Context): Promise<HostingSelection> {
   const hostings = await ctx.pryv.getAvailableHostings();

--- a/src/components/controller/ops/login.js
+++ b/src/components/controller/ops/login.js
@@ -9,7 +9,10 @@ async function login (
   await checkUsername(ctx);
 
   // Login against Pryv
-  ctx.user.personalToken = await ctx.pryv.login(ctx.user.username, password);
+  ctx.user.personalToken = await ctx.pryv.login(
+    ctx.user.username,
+    password,
+    ctx.appId);
 }
 
 export default login;

--- a/src/components/controller/ops/refuse_access.js
+++ b/src/components/controller/ops/refuse_access.js
@@ -1,11 +1,17 @@
 // @flow
 
 import type Context from '../../../Context.js';
-import {RefusedAuthState} from '../../models/AuthStates.js';
+import {REFUSED_STATUS} from '../../models/AuthStates.js';
+import type {RefusedAuthState} from '../../models/AuthStates.js';
 import closeOrRedirect from './close_or_redirect.js';
 
 async function refuseAccess (ctx: Context): Promise<void> {
-  const refusedState = new RefusedAuthState();
+  const refusedState: RefusedAuthState = {
+    status: REFUSED_STATUS,
+    reasonId: 'REFUSED_BY_USER',
+    message: 'The user refused to give access to the requested permissions',
+  };
+
   try {
     // Notify register about refused state
     await ctx.pryv.updateAuthState(ctx.pollKey, refusedState);

--- a/src/components/controller/ops/reset_password.js
+++ b/src/components/controller/ops/reset_password.js
@@ -5,7 +5,7 @@ import checkUsername from './check_username.js';
 
 async function resetPassword (ctx: Context): Promise<void> {
   await checkUsername(ctx);
-  await ctx.pryv.requestPasswordReset(ctx.user.username);
+  await ctx.pryv.requestPasswordReset(ctx.user.username, ctx.appId);
 }
 
 export default resetPassword;

--- a/src/components/models/AuthStates.js
+++ b/src/components/models/AuthStates.js
@@ -32,13 +32,13 @@ export type NeedSigninState = {
   key: string;
   requestingAppId: string;
   requestedPermissions: PermissionsList;
-  returnURL: string;
+  returnURL: ?string;
   poll_rate_ms: number;
-  clientData: mixed;
+  clientData: ?{};
   url: string;
   lang: string;
   poll: string;
-  oauthState: string;
+  oauthState: ?string;
 }
 
 export type AuthState = AcceptedAuthState|RefusedAuthState|ErrorAuthState|NeedSigninState;

--- a/src/components/models/AuthStates.js
+++ b/src/components/models/AuthStates.js
@@ -41,4 +41,5 @@ export type NeedSigninState = {
   oauthState: ?string;
 }
 
-export type AuthState = AcceptedAuthState|RefusedAuthState|ErrorAuthState|NeedSigninState;
+export type TerminationAuthState = AcceptedAuthState|RefusedAuthState|ErrorAuthState;
+export type AuthState = TerminationAuthState|NeedSigninState;

--- a/src/components/models/AuthStates.js
+++ b/src/components/models/AuthStates.js
@@ -8,26 +8,26 @@ export const ERROR_STATUS = 'ERROR';
 export const NEED_SIGNIN_STATUS = 'NEED_SIGNIN';
 
 export type AcceptedAuthState = {
-  status: string;
+  status: 'ACCEPTED';
   username: string;
   token: string;
 }
 
 export type RefusedAuthState = {
-  status: string;
+  status: 'REFUSED';
   reasonId: string;
   message: string;
 }
 
 export type ErrorAuthState = {
-  status: string;
+  status: 'ERROR';
   id: number;
   message: string;
   detail: string;
 }
 
 export type NeedSigninState = {
-  status: string;
+  status: 'NEED_SIGNIN';
   code: number;
   key: string;
   requestingAppId: string;

--- a/src/components/models/AuthStates.js
+++ b/src/components/models/AuthStates.js
@@ -1,86 +1,44 @@
 // @flow
 
-import Permissions from './Permissions.js';
+import type {PermissionsList} from './Permissions.js';
 
-const ACCEPTED_STATUS = 'ACCEPTED';
-const REFUSED_STATUS = 'REFUSED';
-const ERROR_STATUS = 'ERROR';
-const NEED_SIGNIN_STATUS = 'NEED_SIGNIN';
+export const ACCEPTED_STATUS = 'ACCEPTED';
+export const REFUSED_STATUS = 'REFUSED';
+export const ERROR_STATUS = 'ERROR';
+export const NEED_SIGNIN_STATUS = 'NEED_SIGNIN';
 
-export class AcceptedAuthState {
-  body : {
-    status: string,
-    username: string,
-    token: string,
-  }
-
-  constructor (username: string, token: string) {
-    this.body = {
-      status: ACCEPTED_STATUS,
-      username: username,
-      token: token,
-    };
-  }
+export type AcceptedAuthState = {
+  status: string;
+  username: string;
+  token: string;
 }
 
-export class RefusedAuthState {
-  body: {
-    status: string,
-    reasonId: string,
-    message: string,
-  }
-
-  constructor (reasonId: ?string, message: ?string) {
-    this.body = {
-      status: REFUSED_STATUS,
-      reasonId: reasonId || 'REFUSED_BY_USER',
-      message: message || 'The user refused to give access to the requested permissions',
-    };
-  }
+export type RefusedAuthState = {
+  status: string;
+  reasonId: string;
+  message: string;
 }
 
-export class ErrorAuthState {
-  body: {
-    status: string,
-    id: number,
-    message: string,
-    detail: string,
-  }
-
-  constructor (id: number, message: string, detail: string) {
-    this.body = {
-      status: ERROR_STATUS,
-      id: id,
-      message: message,
-      detail: detail,
-    };
-  }
+export type ErrorAuthState = {
+  status: string;
+  id: number;
+  message: string;
+  detail: string;
 }
 
-export class NeedSigninState {
-  body: {
-    status: string,
-    code: number,
-    pollKey: string,
-    appId: string,
-    permissions: Permissions,
-    returnUrl: string,
-    oauthState: string,
-    pollRateMs: number,
-  }
-
-  constructor (data: Object) {
-    this.body = {
-      status: NEED_SIGNIN_STATUS,
-      code: data.code,
-      pollKey: data.key,
-      appId: data.requestingAppId,
-      permissions: new Permissions(data.requestedPermissions),
-      returnUrl: data.returnUrl,
-      oauthState: data.oauthState,
-      pollRateMs: data.poll_rate_ms,
-    };
-  }
+export type NeedSigninState = {
+  status: string;
+  code: number;
+  key: string;
+  requestingAppId: string;
+  requestedPermissions: PermissionsList;
+  returnURL: string;
+  poll_rate_ms: number;
+  clientData: mixed;
+  url: string;
+  lang: string;
+  poll: string;
+  oauthState: string;
 }
 
 export type AuthState = AcceptedAuthState|RefusedAuthState|ErrorAuthState|NeedSigninState;

--- a/src/components/models/Pryv.js
+++ b/src/components/models/Pryv.js
@@ -3,7 +3,7 @@
 import axios from 'axios';
 import Hostings from './Hostings.js';
 import type {AuthState} from './AuthStates.js';
-import type PermissionsList from './Permissions.js';
+import type {PermissionsList} from './Permissions.js';
 
 type AppAccess = {
   type: 'app',
@@ -59,7 +59,7 @@ class Pryv {
   async updateAuthState (pollKey: string, authState: AuthState): Promise<number> {
     const res = await axios.post(
       `${this.register}/access/${pollKey}`,
-      authState.body
+      authState
     );
     return res.status;
   }

--- a/src/components/models/Pryv.js
+++ b/src/components/models/Pryv.js
@@ -101,8 +101,8 @@ class Pryv {
   }
 
   // POST/core: create a new app access, returns the according app token
-  async createAppAccess (username: string, personalToken: string, permissions: PermissionsList,
-    clientData: {}, appToken: ?string, expireAfter: ?number): Promise<AppAccess> {
+  async createAppAccess (username: string, personalToken: string,
+    permissions: PermissionsList, clientData: ?{}, appToken: ?string, expireAfter: ?number): Promise<AppAccess> {
     const res = await axios.post(
       `${this.core(username)}/accesses`, {
         name: this.appId,
@@ -120,7 +120,7 @@ class Pryv {
 
   // PUT/core: update an existing app access, returns the according app token
   async updateAppAccess (accessId: string, username: string, personalToken: string,
-    permissions: PermissionsList, clientData: {}, appToken: ?string, expireAfter: ?number): Promise<AppAccess> {
+    permissions: PermissionsList, clientData: ?{}, appToken: ?string, expireAfter: ?number): Promise<AppAccess> {
     const res = await axios.put(
       `${this.core(username)}/accesses/${accessId}`, {
         name: this.appId,

--- a/src/components/models/Pryv.js
+++ b/src/components/models/Pryv.js
@@ -71,7 +71,7 @@ class Pryv {
         username: username,
         password: password,
         appId: this.appId,
-      }
+      },
     );
     return res.data.token;
   }
@@ -101,8 +101,8 @@ class Pryv {
   }
 
   // POST/core: create a new app access, returns the according app token
-  async createAppAccess (username: string, permissions: PermissionsList,
-    personalToken: string, appToken: ?string, expireAfter: ?number): Promise<AppAccess> {
+  async createAppAccess (username: string, personalToken: string, permissions: PermissionsList,
+    clientData: {}, appToken: ?string, expireAfter: ?number): Promise<AppAccess> {
     const res = await axios.post(
       `${this.core(username)}/accesses`, {
         name: this.appId,
@@ -110,6 +110,7 @@ class Pryv {
         permissions: permissions,
         token: appToken,
         expireAfter: expireAfter,
+        clientData: clientData,
       }, {
         headers: { Authorization: personalToken },
       }
@@ -118,8 +119,8 @@ class Pryv {
   }
 
   // PUT/core: update an existing app access, returns the according app token
-  async updateAppAccess (accessId: string, username: string, permissions: PermissionsList,
-    personalToken: string, appToken: ?string, expireAfter: ?number): Promise<AppAccess> {
+  async updateAppAccess (accessId: string, username: string, personalToken: string,
+    permissions: PermissionsList, clientData: {}, appToken: ?string, expireAfter: ?number): Promise<AppAccess> {
     const res = await axios.put(
       `${this.core(username)}/accesses/${accessId}`, {
         name: this.appId,
@@ -127,6 +128,7 @@ class Pryv {
         permissions: permissions,
         token: appToken,
         expireAfter: expireAfter,
+        clientData: clientData,
       }, {
         headers: { Authorization: personalToken },
       }

--- a/src/components/views/Authorization.vue
+++ b/src/components/views/Authorization.vue
@@ -6,6 +6,7 @@
       v-if="checkedPermissions!=null"
       :appId="ctx.appId"
       :permissionsList="checkedPermissions"
+      :clientData="ctx.clientData"
       @accepted="accept"
       @refused="refuse"/>
 

--- a/src/components/views/Authorization.vue
+++ b/src/components/views/Authorization.vue
@@ -4,9 +4,8 @@
 
     <Permissions
       v-if="checkedPermissions!=null"
-      :appId="ctx.appId"
+      :appId="ctx.requestingAppId"
       :permissionsList="checkedPermissions"
-      :clientData="ctx.clientData"
       @accepted="accept"
       @refused="refuse"/>
 

--- a/src/components/views/RegisterUser.vue
+++ b/src/components/views/RegisterUser.vue
@@ -56,7 +56,7 @@
       </div>
     </v-form>
 
-    <div v-if="ctx.permissions.list != null">
+    <div v-if="ctx.permissions != null">
       <v-divider class="mt-3 mb-2"/>
       <router-link :to="{ name: 'Authorization' }"><h3>Go back to Sign in</h3></router-link>
     </div>
@@ -112,7 +112,7 @@ export default {
             this.newUser = newUser;
             // If the goal was only to register a new user (no requested permissions)
             // then we just redirect the new user to its pryv core
-            if (this.ctx.permissions.list == null) {
+            if (this.ctx.permissions == null) {
               location.href = this.ctx.pryv.core(newUser.username);
             }
             this.success = `New user successfully created: ${newUser.username}.`;

--- a/src/components/views/ResetPassword.vue
+++ b/src/components/views/ResetPassword.vue
@@ -26,7 +26,7 @@
       >{{ buttonText }}</v-btn>
     </v-form>
 
-    <div v-if="ctx.permissions.list != null">
+    <div v-if="ctx.permissions != null">
       <v-divider class="mt-3 mb-2"/>
       <router-link :to="{ name: 'Authorization' }"><h3>Go back to Sign in</h3></router-link>
     </div>

--- a/src/components/views/bits/Permissions.vue
+++ b/src/components/views/bits/Permissions.vue
@@ -18,9 +18,6 @@
           </li>
         </ul>
       </v-card-text>
-      <v-card-text v-if="clientData.consent">
-        {{ clientData.consent }}
-      </v-card-text>
       <v-divider/>
       <v-card-actions>
         <v-spacer/>
@@ -42,7 +39,6 @@ export default {
   props: {
     permissionsList: {type: Array, default: () => ([])},
     appId: {type: String, default: ''},
-    clientData: {type: Object, default: () => {}},
   },
   data: () => ({
     dialog: true,

--- a/src/components/views/bits/Permissions.vue
+++ b/src/components/views/bits/Permissions.vue
@@ -18,6 +18,9 @@
           </li>
         </ul>
       </v-card-text>
+      <v-card-text v-if="clientData.consent">
+        {{ clientData.consent }}
+      </v-card-text>
       <v-divider/>
       <v-card-actions>
         <v-spacer/>
@@ -39,6 +42,7 @@ export default {
   props: {
     permissionsList: {type: Array, default: () => ([])},
     appId: {type: String, default: ''},
+    clientData: {type: Object, default: () => {}},
   },
   data: () => ({
     dialog: true,

--- a/src/context.js
+++ b/src/context.js
@@ -20,10 +20,10 @@ class Context {
   clientData: mixed;
 
   constructor (queryParams) {
-    const domain = domainFromUrl() || 'pryv.me';
+    this.domain = domainFromUrl() || 'pryv.me';
     this.language = 'en';
     this.appId = 'pryv-app-web-auth-3';
-    this.pryv = new Pryv(domain, this.appId);
+    this.pryv = new Pryv(this.domain, this.appId);
     this.pollKey = queryParams.key;
     this.user = {
       username: '',

--- a/src/context.js
+++ b/src/context.js
@@ -4,6 +4,11 @@ import Pryv from './components/models/Pryv.js';
 import Permissions from './components/models/Permissions.js';
 import type {NeedSigninState} from './components/models/AuthStates.js';
 
+type QueryParameters = {
+  key: string,
+  lang: ?string
+}
+
 class Context {
   domain: string;
   appId: string; // id of the web-auth app
@@ -20,7 +25,7 @@ class Context {
   }
   clientData: ?{};
 
-  constructor (queryParams) {
+  constructor (queryParams: QueryParameters) {
     this.domain = domainFromUrl() || 'pryv.me';
     this.language = queryParams.lang || 'en';
     this.appId = 'pryv-app-web-auth-3';

--- a/src/context.js
+++ b/src/context.js
@@ -17,10 +17,10 @@ class Context {
     username: string,
     personalToken: string,
   }
-  clientData: mixed;
+  clientData: ?{};
 
   constructor (queryParams) {
-    this.domain = domainFromUrl() || 'pryv.me';
+    this.domain = domainFromUrl() || 'rec.la';
     this.language = 'en';
     this.appId = 'pryv-app-web-auth-3';
     this.pryv = new Pryv(this.domain, this.appId);

--- a/src/context.js
+++ b/src/context.js
@@ -1,21 +1,44 @@
+// @flow
+
 import Pryv from './components/models/Pryv.js';
 import Permissions from './components/models/Permissions.js';
+import type {NeedSigninState} from './components/models/AuthStates.js';
 
 class Context {
+  domain: string;
+  appId: string;
+  language: string;
+  returnURL: string;
+  oauthState: string;
+  permissions: Permissions;
+  pollKey: string;
+  pryv: Pryv;
+  user: {
+    username: string,
+    personalToken: string,
+  }
+  clientData: mixed;
+
   constructor (queryParams) {
-    const domain = domainFromUrl() || queryParams.domain || 'pryv.me';
-    const appId = queryParams.requestingAppId || 'pryv-app-web-auth-3';
-    this.language = queryParams.lang || 'en';
-    this.appId = appId;
-    this.returnURL = queryParams.returnURL;
-    this.oauthState = queryParams.oauthState;
-    this.permissions = new Permissions(queryParams.requestedPermissions);
+    const domain = domainFromUrl() || 'pryv.me';
+    this.language = 'en';
+    this.appId = 'pryv-app-web-auth-3';
+    this.pryv = new Pryv(domain, this.appId);
     this.pollKey = queryParams.key;
-    this.pryv = new Pryv(domain, appId);
     this.user = {
       username: '',
       personalToken: '',
     };
+  }
+
+  syncFromAuthState (state: NeedSigninState) {
+    this.clientData = state.clientData;
+    this.appId = state.requestingAppId;
+    this.permissions = new Permissions(state.requestedPermissions);
+    this.pryv = new Pryv(this.domain, this.appId);
+    this.returnURL = state.returnURL;
+    this.oauthState = state.oauthState;
+    this.language = state.lang;
   }
 }
 

--- a/src/context.js
+++ b/src/context.js
@@ -6,10 +6,11 @@ import type {NeedSigninState} from './components/models/AuthStates.js';
 
 class Context {
   domain: string;
-  appId: string;
+  appId: string; // id of the web-auth app
+  requestingAppId: string; // id of the app requesting access
   language: string;
-  returnURL: string;
-  oauthState: string;
+  returnURL: ?string;
+  oauthState: ?string;
   permissions: Permissions;
   pollKey: string;
   pryv: Pryv;
@@ -20,10 +21,10 @@ class Context {
   clientData: ?{};
 
   constructor (queryParams) {
-    this.domain = domainFromUrl() || 'rec.la';
-    this.language = 'en';
+    this.domain = domainFromUrl() || 'pryv.me';
+    this.language = queryParams.lang || 'en';
     this.appId = 'pryv-app-web-auth-3';
-    this.pryv = new Pryv(this.domain, this.appId);
+    this.pryv = new Pryv(this.domain);
     this.pollKey = queryParams.key;
     this.user = {
       username: '',
@@ -31,14 +32,13 @@ class Context {
     };
   }
 
-  syncFromAuthState (state: NeedSigninState) {
+  updateFromAuthState (state: NeedSigninState) {
     this.clientData = state.clientData;
-    this.appId = state.requestingAppId;
+    this.requestingAppId = state.requestingAppId;
     this.permissions = new Permissions(state.requestedPermissions);
-    this.pryv = new Pryv(this.domain, this.appId);
     this.returnURL = state.returnURL;
     this.oauthState = state.oauthState;
-    this.language = state.lang;
+    if (state.lang != null) this.language = state.lang;
   }
 }
 

--- a/tests/e2e/register.test.js
+++ b/tests/e2e/register.test.js
@@ -51,7 +51,7 @@ const redirectMock = RequestMock()
   .respond(null, 200, {'Access-Control-Allow-Origin': '*'});
 
 fixture(`Register user`)
-  .page('http://localhost:8080/register?requestingAppId=pryv-reg-standalone&standaloneRegister=true')
+  .page('http://localhost:8080/register?lang=fr')
   .requestHooks(registerLogger, hostingsLogger, registerUserMock, hostingsMock, redirectMock);
 
 test('Register new user with hostings retrieval', async testController => {
@@ -75,12 +75,12 @@ test('Register new user with hostings retrieval', async testController => {
     .expect(registerLogger.contains(record =>
       record.request.method === 'post' &&
       record.response.statusCode === 200 &&
-      record.request.body.includes('"appid":"pryv-reg-standalone"') &&
+      record.request.body.includes('"appid":"pryv-app-web-auth-3"') &&
       record.request.body.includes('"username":"tmodoux"') &&
       record.request.body.includes('"password":"mypass"') &&
       record.request.body.includes('"email":"test@test.com"') &&
       record.request.body.includes('"hosting":"gandi.net-fr"') &&
-      record.request.body.includes('"languageCode":"en"') &&
+      record.request.body.includes('"languageCode":"fr"') &&
       record.request.body.includes('"invitationtoken":"enjoy"')
     )).ok();
 });

--- a/tests/e2e/resetPassword.test.js
+++ b/tests/e2e/resetPassword.test.js
@@ -23,7 +23,7 @@ const usernameForEmailMock = RequestMock()
   .respond({uid: 'tmodoux'}, 200, {'Access-Control-Allow-Origin': '*'});
 
 fixture(`Reset password`)
-  .page('http://localhost:8080/reset?resetToken=1234&requestingAppId=pryv-reset-standalone&standaloneReset=true')
+  .page('http://localhost:8080/reset?resetToken=1234')
   .requestHooks(resetLogger, emailLogger, resetRequestMock, usernameForEmailMock);
 
 test('Reset password with email conversion', async testController => {
@@ -46,7 +46,7 @@ test('Reset password with email conversion', async testController => {
     .expect(resetLogger.contains(record =>
       record.request.method === 'post' &&
       record.response.statusCode === 200 &&
-      record.request.body.includes('"appId":"pryv-reset-standalone"') &&
+      record.request.body.includes('"appId":"pryv-app-web-auth-3"') &&
       record.request.body.includes('"username":"tmodoux"') &&
       record.request.body.includes('"newPassword":"123456789"') &&
       record.request.body.includes('"resetToken":"1234"')

--- a/tests/e2e/resetPasswordRequest.test.js
+++ b/tests/e2e/resetPasswordRequest.test.js
@@ -23,7 +23,7 @@ const usernameForEmailMock = RequestMock()
   .respond({uid: 'tmodoux'}, 200, {'Access-Control-Allow-Origin': '*'});
 
 fixture(`Reset password request`)
-  .page('http://localhost:8080/reset?requestingAppId=pryv-reset-standalone&standaloneReset=true')
+  .page('http://localhost:8080/reset')
   .requestHooks(resetLogger, emailLogger, resetRequestMock, usernameForEmailMock);
 
 test('Reset request with email-username conversion', async testController => {
@@ -44,7 +44,7 @@ test('Reset request with email-username conversion', async testController => {
     .expect(resetLogger.contains(record =>
       record.request.method === 'post' &&
       record.response.statusCode === 200 &&
-      record.request.body.includes('"appId":"pryv-reset-standalone"') &&
+      record.request.body.includes('"appId":"pryv-app-web-auth-3"') &&
       record.request.body.includes('"username":"tmodoux"')
     )).ok()
     .expect(Selector('body').textContent).contains('We have sent password reset instructions to your e-mail address.');


### PR DESCRIPTION
We will add clientData fields to accesses. This means: 
* Adding it to registry (pass-through)
* Adding it to lib-js (Pryv login button)
* **Adding it to app-web-auth3 (auth request)**
* Adding it to core (CRUD)

This PR also includes a preliminary work to rely only on 'pollKey' as query parameter and poll other parameters from register (NEED_SIGNIN state). Which also led to improving context setup and flow typing.