### PR TITLE
Do not show Sign in button for standalone register

### DIFF
--- a/src/components/views/RegisterUser.vue
+++ b/src/components/views/RegisterUser.vue
@@ -56,8 +56,10 @@
       </div>
     </v-form>
 
-    <v-divider class="mt-3 mb-2"/>
-    <router-link :to="{ name: 'Authorization' }"><h3>Go to Sign in</h3></router-link>
+    <div v-if="ctx.permissions != null">
+      <v-divider class="mt-3 mb-2"/>
+      <router-link :to="{ name: 'Authorization' }"><h3>Go to Sign in</h3></router-link>
+    </div>
 
     <Alerts
       :successMsg="success"

--- a/src/components/views/RegisterUser.vue
+++ b/src/components/views/RegisterUser.vue
@@ -56,7 +56,7 @@
       </div>
     </v-form>
 
-    <div v-if="ctx.permissions != null">
+    <div v-if="ctx.pollKey != null">
       <v-divider class="mt-3 mb-2"/>
       <router-link :to="{ name: 'Authorization' }"><h3>Go to Sign in</h3></router-link>
     </div>

--- a/src/components/views/ResetPassword.vue
+++ b/src/components/views/ResetPassword.vue
@@ -26,7 +26,7 @@
       >{{ buttonText }}</v-btn>
     </v-form>
 
-    <div v-if="ctx.permissions != null">
+    <div v-if="ctx.pollKey != null">
       <v-divider class="mt-3 mb-2"/>
       <router-link :to="{ name: 'Authorization' }"><h3>Go to Sign in</h3></router-link>
     </div>

--- a/src/components/views/ResetPassword.vue
+++ b/src/components/views/ResetPassword.vue
@@ -26,8 +26,10 @@
       >{{ buttonText }}</v-btn>
     </v-form>
 
-    <v-divider class="mt-3 mb-2"/>
-    <router-link :to="{ name: 'Authorization' }"><h3>Go to Sign in</h3></router-link>
+    <div v-if="ctx.permissions != null">
+      <v-divider class="mt-3 mb-2"/>
+      <router-link :to="{ name: 'Authorization' }"><h3>Go to Sign in</h3></router-link>
+    </div>
 
     <Alerts
       :successMsg="success"

--- a/tests/unit/views/__snapshots__/RegisterUser.test.js.snap
+++ b/tests/unit/views/__snapshots__/RegisterUser.test.js.snap
@@ -91,17 +91,7 @@ exports[`RegisterUser.test.js renders correctly (snapshots matching) 1`] = `
     </div>
   </vform-stub>
    
-  <vdivider-stub
-    class="mt-3 mb-2"
-  />
-   
-  <router-link-stub
-    to="[object Object]"
-  >
-    <h3>
-      Go to Sign in
-    </h3>
-  </router-link-stub>
+  <!---->
    
   <alerts-stub
     errormsg=""

--- a/tests/unit/views/__snapshots__/ResetPassword.test.js.snap
+++ b/tests/unit/views/__snapshots__/ResetPassword.test.js.snap
@@ -29,17 +29,7 @@ exports[`ResetPassword.test.js renders correctly (snapshots matching) 1`] = `
     </vbtn-stub>
   </vform-stub>
    
-  <vdivider-stub
-    class="mt-3 mb-2"
-  />
-   
-  <router-link-stub
-    to="[object Object]"
-  >
-    <h3>
-      Go to Sign in
-    </h3>
-  </router-link-stub>
+  <!---->
    
   <alerts-stub
     errormsg=""


### PR DESCRIPTION
Hide 'Go to Sign in' button when it makes no sense (i.e. no poll key)