### PR TITLE
feat: align with narrow auth-flow surface; ?cli=1 terminal screen + bug fixes

### DIFF
--- a/src/components/controller/ops/close_or_redirect.js
+++ b/src/components/controller/ops/close_or_redirect.js
@@ -10,6 +10,13 @@ function closeOrRedirect (ctx: Context): void {
     return;
   }
 
+  // Multi-core auth handoff: the access moved to a different core; the
+  // auth UI follows the new poll URL rather than completing here.
+  if (ctx.accessState.status === 'REDIRECTED' && ctx.accessState.redirectUrl) {
+    location.href = ctx.accessState.redirectUrl;
+    return;
+  }
+
   let returnUrl = ctx.accessState.returnURL;
   // If no return URL was provided, just close the popup
   if (returnUrl == null || returnUrl === 'false' || !returnUrl) {
@@ -22,12 +29,12 @@ function closeOrRedirect (ctx: Context): void {
       returnUrl += '?';
     }
 
-    if (ctx.accessState.oaccessState) { // OK to use pollKey here
-      let pollKey = '';
+    if (ctx.accessState.oauthState) {
+      let codeParam = '';
       if (ctx.accessState.key) {
-        pollKey = `&code=${ctx.accessState.key}`;
+        codeParam = `&code=${ctx.accessState.key}`;
       }
-      returnUrl += `state=${ctx.accessState.oaccessState}${pollKey}&poll=${ctx.pollUrl}`;
+      returnUrl += `state=${ctx.accessState.oauthState}${codeParam}&poll=${ctx.pollUrl}`;
     } else {
       returnUrl += `prYvpoll=${ctx.pollUrl}`;
       // the following code should be deprecated

--- a/src/components/controller/ops/close_or_redirect.js
+++ b/src/components/controller/ops/close_or_redirect.js
@@ -3,6 +3,13 @@
 import type Context from '../../../context.js';
 
 function closeOrRedirect (ctx: Context): void {
+  // Headless caller (CLI) — no popup to close, no parent window to redirect.
+  // Render a terminal "you can close this window" message and stop.
+  if (ctx.cli) {
+    renderCliTerminalMessage();
+    return;
+  }
+
   let returnUrl = ctx.accessState.returnURL;
   // If no return URL was provided, just close the popup
   if (returnUrl == null || returnUrl === 'false' || !returnUrl) {
@@ -31,6 +38,21 @@ function closeOrRedirect (ctx: Context): void {
       }
     }
     location.href = returnUrl;
+  }
+}
+
+function renderCliTerminalMessage (): void {
+  const message = 'You\'re successfully logged in, you can close this window.';
+  document.title = 'Logged in';
+  const root = document.getElementById('app') || document.body;
+  if (root) {
+    root.innerHTML =
+      '<div style="' +
+      'font-family: system-ui, -apple-system, sans-serif;' +
+      'display: flex; align-items: center; justify-content: center;' +
+      'min-height: 100vh; padding: 2em; text-align: center;' +
+      'font-size: 1.25em; color: #333;' +
+      '">' + message + '</div>';
   }
 }
 

--- a/src/components/models/AccessStates.js
+++ b/src/components/models/AccessStates.js
@@ -12,21 +12,18 @@ export type AccessState = {
 
   // status=NEED_SIGNIN
   serviceInfo?: ServiceInfos,
-  code?: number,
   key?: string,
   requestingAppId?: string,
   requestedPermissions?: PermissionsList,
   returnURL?: string,
   poll_rate_ms?: number,
   clientData?: Object,
-  url?: string,
   lang?: string,
   poll?: string,
-  pollKey?: string, // why is this still here?
-  oaccessState?: string,
-  expireAfter?: number, // to be added
-  deviceName?: string, // to be added
-  referer?: string, // to be added
+  oauthState?: string,
+  expireAfter?: number,
+  deviceName?: string,
+  referer?: string,
 
   // status=ACCEPTED
   username?: string,
@@ -36,4 +33,7 @@ export type AccessState = {
   // status=REFUSED
   reasonId?: string;
   message?: string;
+
+  // status=REDIRECTED (multi-core)
+  redirectUrl?: string;
 }

--- a/src/context.js
+++ b/src/context.js
@@ -40,13 +40,17 @@ class Context {
     this.cli = queryParams.cli === '1';
     if (queryParams != null && queryParams.oauthState != null) {
       this.accessState = {
-        oaccessState: queryParams.oauthState,
+        oauthState: queryParams.oauthState,
       };
     }
 
     if (this.isAccessRequest()) {
-      // Context will set necessary serviceInfo during Context.init();
-      this.pryvService = new Pryv.Service();
+      // Context normally sets serviceInfo from the poll response during
+      // Context.init(); derive a serviceInfoUrl from the poll URL as a
+      // fallback so `pryvService.info()` works even if a future server
+      // stops embedding serviceInfo in the poll body.
+      const fallbackServiceInfoUrl = deriveServiceInfoUrlFromPollUrl(this.pollUrl);
+      this.pryvService = new Pryv.Service(fallbackServiceInfoUrl);
     } else {
       const serviceInfoUrl = queryParams.pryvServiceInfoUrl || defaultPryvServiceInfoUrl();
       this.pryvService = new Pryv.Service(serviceInfoUrl);
@@ -65,7 +69,14 @@ class Context {
     this.initialized = false;
     if (this.isAccessRequest()) {
       await this.loadAccessState();
-      this.pryvService.setServiceInfo(this.accessState.serviceInfo);
+      // serviceInfo may be embedded in the poll response (legacy behaviour)
+      // or omitted (newer servers only embed it on the initial access POST
+      // and on the ACCEPTED state). Skip setServiceInfo if absent — the
+      // pryvService.info() call below falls back to fetching it from
+      // the platform's /service/info endpoint.
+      if (this.accessState.serviceInfo) {
+        this.pryvService.setServiceInfo(this.accessState.serviceInfo);
+      }
     }
     await this.pryvService.info();
   }
@@ -98,6 +109,19 @@ class Context {
     if (this.accessState.lang != null) this.language = this.accessState.lang;
     return res.status;
   }
+}
+
+/**
+ * The poll URL is always shaped `{coreUrl}/reg/access/{key}` (see
+ * open-pryv.io `routes/reg/access.ts`). Replace the trailing
+ * `access/{key}` with `service/info` to get a service-info URL on the
+ * same core. Returns null if the URL doesn't match the expected shape.
+ */
+function deriveServiceInfoUrlFromPollUrl (pollUrl: ?string): ?string {
+  if (pollUrl == null) return null;
+  const m = /^(.*\/reg\/)access\/[^/]+\/?$/.exec(pollUrl);
+  if (m == null) return null;
+  return m[1] + 'service/info';
 }
 
 /**

--- a/src/context.js
+++ b/src/context.js
@@ -14,6 +14,7 @@ type QueryParameters = {
   pollUrl: string; // should be removed from register's authUrl response and use "poll" only
   lang?: string,
   oauthState?: string, // ifttt
+  cli?: string, // '1' when the calling app is headless and there is no popup/parent window to close or redirect
 }
 
 class Context {
@@ -29,12 +30,14 @@ class Context {
     mfaToken: string,
   };
   initialized: boolean;
+  cli: boolean; // true when the auth UI was launched by a headless caller (no popup/parent window)
 
   constructor (queryParams: QueryParameters) {
     console.log('QUERY PARAMS', queryParams);
     this.language = queryParams.lang || 'en';
     this.appId = 'pryv-app-web-auth-3';
     this.pollUrl = queryParams.poll || queryParams.pollUrl;
+    this.cli = queryParams.cli === '1';
     if (queryParams != null && queryParams.oauthState != null) {
       this.accessState = {
         oaccessState: queryParams.oauthState,


### PR DESCRIPTION
## Summary

Two-commit alignment with the coordinated auth-flow narrowing in `pryv@3.5.0` + the server-side trim in `pryv/open-pryv.io`.

### Phase B — headless / CLI UX
- New `?cli=1` query flag on the auth URL: when the calling app is headless (no popup, no parent window to redirect to), the auth UI renders **"You're successfully logged in, you can close this window."** instead of `window.close()` / redirect.
- Parsed in `Context` (`queryParams.cli === '1'`) and consumed in `closeOrRedirect()`.

### Phase C — alignment + bug fixes
- `oaccessState` typo (vs the `oauthState` the server emits) corrected in the write path (`context.js`) and read paths (`close_or_redirect.js`, `AccessStates.js` Flow model).
- `REDIRECTED` status now handled in `closeOrRedirect()` — the auth UI follows the new poll URL instead of falling through to the popup-close path.
- Dead `pollKey` field dropped from the `AccessState` model.
- `code` (HTTP status echoed in body) + `url` (v1 alias of `authUrl`) dropped — the server no longer emits them.
- `context.js` derives a fallback `/service/info` URL from the poll URL so `pryvService.info()` keeps working even when the server stops embedding `serviceInfo` in every poll. `Context.init()` no longer crashes when `serviceInfo` is absent from the poll body.

## Commits

1. `e8f3bcd` — feat: `?cli=1` query flag renders terminal "you can close" screen
2. `0798eff` — feat: align with narrow auth-flow surface; fix oaccessState/REDIRECTED bugs

## Test plan

- [x] `yarn lint` — clean
- [ ] `yarn unit` — pre-existing broken on modern Node (Jest 23 vs yargs-parser resolution); CI does docker build, not unit tests
- [ ] Manual smoke: open a `pryv.Browser.setupAuth(...)` flow against a server with the matching `open-pryv.io` build and confirm the popup-close path + redirect path + CLI path all work
- [ ] Coordinated changes in `pryv/lib-js` + `pryv/open-pryv.io` (PRs linked below) — needs to land in lockstep

## Coordinated release

- `pryv/lib-js#69` — SDK-side narrowing (calling-app surface)
- `pryv/open-pryv.io#...` — server-side response-shape trim

The fallback `/service/info` derivation in `context.js` means this build keeps working against older `open-pryv.io` servers that still embed `serviceInfo` on every poll (backwards-compat is preserved).